### PR TITLE
fix(toggl): unable to add new projects

### DIFF
--- a/src/toggl.js
+++ b/src/toggl.js
@@ -48,6 +48,7 @@ export async function createProject(name, workspaceId, apiKey) {
       `workspaces/${workspaceId}/projects`,
       {
         name: name,
+        active: true,
       },
       {
         auth: {


### PR DESCRIPTION
Toggl introduced a new step that makes new projects archived by default, or did they stop allowing adding entries to archived projects?

Either way, I included the active field to make the project active during creation so entries can be added.